### PR TITLE
Purge expired bulletins on access

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,5 +73,29 @@ Find the latest release in the Releases tab and download a package (I generally 
 3. Access the webpage and configure user accounts and settings (located in the control panel)
 3. All good to go!
 
+---
+
+## running with Docker
+If you prefer a containerized setup, you can use Docker to build and run MyOp.
+
+### build the image
+From the repository root:
+```
+docker build -t myop .
+```
+
+### run the container
+This starts the app and exposes it on port 5000:
+```
+docker run --rm -p 5000:5000 myop
+```
+
+Then open `http://localhost:5000/` in your browser.
+
+### persisting data
+The SQLite database is stored in `myop.db`. To persist data across container restarts, mount a volume:
+```
+docker run --rm -p 5000:5000 -v "$(pwd)/myop.db:/app/myop.db" myop
+```
 
 

--- a/app.py
+++ b/app.py
@@ -402,7 +402,10 @@ def allbulletins():
 @logged_in()
 @needs_csrf
 def onebulletin(id: int):
-    bulletin = bullfunc.Bulletin(id)
+    try:
+        bulletin = bullfunc.Bulletin(id)
+    except ReferenceError:
+        abort(404, "Bulletin not found.")
     if request.method == "GET":
         return render_template("view_bulletin.html", bulletin=bulletin)
     elif request.method == "UPDATE":

--- a/app.py
+++ b/app.py
@@ -243,7 +243,7 @@ def add_user():
         app.config["BOOTSTRAP_ADMIN"] = None
         session.clear()
         return redirect("/login", 301)
-    log.info(f"New user added! \nCallsign: {newuser["callsign"]}")
+    log.info(f"New user added! \nCallsign: {newuser['callsign']}")
     return redirect("/control", 301)
 
 
@@ -292,7 +292,7 @@ def view_or_edit_user(id: int):
                 return str(e), 500
         if f["pwdhash"] is not None:
             user.set_new_password(f["pwdhash"])
-            log.info(f"{coloredText(user.callsign, 36)}'s password was changed by {coloredText(session["user"], 31)}")
+            log.info(f"{coloredText(user.callsign, 36)}'s password was changed by {coloredText(session['user'], 31)}")
         return "Changes saved", 200
 
 
@@ -442,7 +442,7 @@ def chat():
 @websocket.on("message")
 def newMsg(data):
     try:
-        print(f"New Message: {data.get("msg", " ")}\nFrom station: {data.get("username")}")
+        print(f"New Message: {data.get('msg', ' ')}\nFrom station: {data.get('username')}")
         dataToSend = {
             "timestamp": time.asctime(),
             "username": data.get("username", "unknown"),


### PR DESCRIPTION
### Motivation
- Prevent expired bulletin entries from being served or listed by removing them when accessed so the bulletin board does not show stale posts.

### Description
- Delete an expired bulletin when loading by id in `bullfunc.Bulletin.__init__` and raise a `ReferenceError` for expired items so callers can handle them (now returning 404 in `app.py`).
- Add `Bulletin.purge_expired()` to delete all expired records up to a given timestamp and call it from `get_all_bulletins` and `filter_user` to ensure lists are cleaned before returning.
- Make `_load_from_row` tolerate `NULL` `expires` values by mapping them to `None` instead of casting unconditionally to `int`.
- Wrap `Bulletin(id)` usage in `app.py` with `try/except ReferenceError` and `abort(404, ...)` to return a proper HTTP response for missing/expired bulletins.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989c4cf0bf8832397cfd39bbecc5585)